### PR TITLE
Fix options.forceBuild check

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,8 @@ module.exports = function(grunt){
 	}
 
 	grunt.registerTask('build', function(options){
-		if(options.indexOf('forceBuild')!==-1){
+		options = options || {};
+		if(typeof options.forceBuild != 'undefined'){
 			for(site in sites){
 				grunt.config('documentjs.sites.' + site + '.forceBuild', true);
 			}


### PR DESCRIPTION
Was getting errors about undefined when trying to do `grunt build` like the README suggests.